### PR TITLE
Fix issue wrong reduction amount if no tax

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -987,12 +987,14 @@ class CartRuleCore extends ObjectModel
                     foreach ($package_products as $product) {
                         if (in_array($product['id_product'].'-'.$product['id_product_attribute'], $selected_products)
                             || in_array($product['id_product'].'-0', $selected_products)) {
-                            $price = $product['price'];
-                            if ($use_tax) {
-                                $infos = Product::getTaxesInformations($product, $context);
-                                $tax_rate = $infos['rate'] / 100;
-                                $price *= (1 + $tax_rate);
-                            }
+                            $price = Product::getPriceStatic($product['id_product'],
+                                $use_tax,
+                                isset($product['id_product_attribute']) ? (int)$product['id_product_attribute'] : null,
+                                6,
+                                null,
+                                false,
+                                false,
+                                $product['cart_quantity']);
 
                             $selected_products_reduction += $price * $product['cart_quantity'];
                         }


### PR DESCRIPTION
Fix the issue if you have a reduction cart rule with amount or % of reduction on products/categories/manufacturers and the order has no tax due to country or VATNUMBER entered. The reduction is calculated with tax. So you have a payement error because the total order is different that the real paied.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Fix the reduction amount calculation if no tax due to delivery address or VAT NUMBER entered.
| Type?         | bug fix
| Category?     | FO / BO / CO 
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | 
| How to test?  | Create a cart rule based on all products, categories or manufacturers with a % reduction 5% by example. Add product to cart and enter the voucher code corresponding to that rule. Select a country with no tax in address or enter a VATNUMBER. In front office the reduction amount is ok. But if you look at the cart in BO the amount is false, is calculated with tax. If the customer validate order there is a payment error the real paied is superior than total order. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
